### PR TITLE
harden reconcile context, validation, and storage guards

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -4,6 +4,7 @@
     ".": {
       "release-type": "go",
       "package-name": "bobrapet",
+      "include-component-in-tag": false,
       "changelog-sections": [
         { "type": "feat",     "section": "Features",                   "hidden": false },
         { "type": "fix",      "section": "Bug Fixes",                  "hidden": false },

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -58,6 +58,7 @@ jobs:
             type=semver,pattern={{version}},value=${{ steps.release.outputs.tag_name }}
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.release.outputs.tag_name }}
             type=semver,pattern={{major}},value=${{ steps.release.outputs.tag_name }}
+            type=raw,value=${{ steps.release.outputs.tag_name }}
             type=raw,value=latest
 
       - name: Build and push Docker image
@@ -94,6 +95,21 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload ${{ steps.release.outputs.tag_name }} dist/install.yaml
+
+      - name: Warm Go module caches (proxy/sum/pkg.go.dev)
+        if: ${{ steps.release.outputs.release_created }}
+        run: |
+          set -euo pipefail
+          MOD=github.com/${{ github.repository }}
+          VER=${{ steps.release.outputs.tag_name }}
+          echo "Warming proxy.golang.org for $MOD@$VER"
+          curl -sSfL "https://proxy.golang.org/${MOD}/@v/${VER}.info" || true
+          echo "Warming sum.golang.org for $MOD@$VER"
+          curl -sSfL "https://sum.golang.org/lookup/${MOD}@${VER}" || true
+          echo "Triggering pkg.go.dev indexing for $MOD@$VER"
+          curl -sSfL "https://pkg.go.dev/${MOD}@${VER}" > /dev/null || true
+          echo "Triggering Go Report Card for $MOD"
+          curl -X POST -F "repo=${MOD}" https://goreportcard.com/checks
 
       - name: Create release summary
         if: ${{ steps.release.outputs.release_created }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,8 @@ linters:
     - unparam
     - unused
   settings:
+    gocyclo:
+      min-complexity: 15
     revive:
       rules:
         - name: comment-spacings

--- a/internal/config/operator.go
+++ b/internal/config/operator.go
@@ -182,39 +182,65 @@ func (ocm *OperatorConfigManager) parseConfigMap(cm *corev1.ConfigMap, config *O
 	parseStoryRunConfig(cm, config)
 }
 
-// --- helpers below keep parseConfigMap readable and reduce cyclomatic complexity ---
-
 func parseControllerTimings(cm *corev1.ConfigMap, config *OperatorConfig) {
+	setMaxConcurrentReconciles(cm, config)
+	setRequeueBaseDelay(cm, config)
+	setRequeueMaxDelay(cm, config)
+	setHealthCheckInterval(cm, config)
+	setCleanupInterval(cm, config)
+	setReconcileTimeout(cm, config)
+	setDefaultEngramGRPCPort(cm, config)
+}
+
+func setMaxConcurrentReconciles(cm *corev1.ConfigMap, config *OperatorConfig) {
 	if val, exists := cm.Data["controller.max-concurrent-reconciles"]; exists {
 		if parsed, err := strconv.Atoi(val); err == nil && parsed > 0 {
 			config.Controller.MaxConcurrentReconciles = parsed
 		}
 	}
+}
+
+func setRequeueBaseDelay(cm *corev1.ConfigMap, config *OperatorConfig) {
 	if val, exists := cm.Data["controller.requeue-base-delay"]; exists {
 		if parsed, err := time.ParseDuration(val); err == nil {
 			config.Controller.RequeueBaseDelay = parsed
 		}
 	}
+}
+
+func setRequeueMaxDelay(cm *corev1.ConfigMap, config *OperatorConfig) {
 	if val, exists := cm.Data["controller.requeue-max-delay"]; exists {
 		if parsed, err := time.ParseDuration(val); err == nil {
 			config.Controller.RequeueMaxDelay = parsed
 		}
 	}
+}
+
+func setHealthCheckInterval(cm *corev1.ConfigMap, config *OperatorConfig) {
 	if val, exists := cm.Data["controller.health-check-interval"]; exists {
 		if parsed, err := time.ParseDuration(val); err == nil {
 			config.Controller.HealthCheckInterval = parsed
 		}
 	}
+}
+
+func setCleanupInterval(cm *corev1.ConfigMap, config *OperatorConfig) {
 	if val, exists := cm.Data["controller.cleanup-interval"]; exists {
 		if parsed, err := time.ParseDuration(val); err == nil {
 			config.Controller.CleanupInterval = metav1.Duration{Duration: parsed}
 		}
 	}
+}
+
+func setReconcileTimeout(cm *corev1.ConfigMap, config *OperatorConfig) {
 	if val, exists := cm.Data["controller.reconcile-timeout"]; exists {
 		if parsed, err := time.ParseDuration(val); err == nil {
 			config.Controller.ReconcileTimeout = parsed
 		}
 	}
+}
+
+func setDefaultEngramGRPCPort(cm *corev1.ConfigMap, config *OperatorConfig) {
 	if val, exists := cm.Data["controller.default-engram-grpc-port"]; exists {
 		if parsed, err := strconv.Atoi(val); err == nil && parsed > 0 {
 			config.Controller.DefaultEngramGRPCPort = parsed
@@ -257,36 +283,64 @@ func parseResourceLimits(cm *corev1.ConfigMap, config *OperatorConfig) {
 }
 
 func parseRetryAndTimeouts(cm *corev1.ConfigMap, config *OperatorConfig) {
+	setMaxRetries(cm, config)
+	setExponentialBackoffBase(cm, config)
+	setExponentialBackoffMax(cm, config)
+	setDefaultStepTimeout(cm, config)
+	setApprovalDefaultTimeout(cm, config)
+	setExternalDataTimeout(cm, config)
+	setConditionalTimeout(cm, config)
+}
+
+func setMaxRetries(cm *corev1.ConfigMap, config *OperatorConfig) {
 	if val, exists := cm.Data["retry.max-retries"]; exists {
 		if parsed, err := strconv.Atoi(val); err == nil && parsed >= 0 {
 			config.Controller.MaxRetries = parsed
 		}
 	}
+}
+
+func setExponentialBackoffBase(cm *corev1.ConfigMap, config *OperatorConfig) {
 	if val, exists := cm.Data["retry.exponential-backoff-base"]; exists {
 		if parsed, err := time.ParseDuration(val); err == nil {
 			config.Controller.ExponentialBackoffBase = parsed
 		}
 	}
+}
+
+func setExponentialBackoffMax(cm *corev1.ConfigMap, config *OperatorConfig) {
 	if val, exists := cm.Data["retry.exponential-backoff-max"]; exists {
 		if parsed, err := time.ParseDuration(val); err == nil {
 			config.Controller.ExponentialBackoffMax = parsed
 		}
 	}
+}
+
+func setDefaultStepTimeout(cm *corev1.ConfigMap, config *OperatorConfig) {
 	if val, exists := cm.Data["timeout.default-step"]; exists {
 		if parsed, err := time.ParseDuration(val); err == nil {
 			config.Controller.DefaultStepTimeout = parsed
 		}
 	}
+}
+
+func setApprovalDefaultTimeout(cm *corev1.ConfigMap, config *OperatorConfig) {
 	if val, exists := cm.Data["timeout.approval-default"]; exists {
 		if parsed, err := time.ParseDuration(val); err == nil {
 			config.Controller.ApprovalDefaultTimeout = parsed
 		}
 	}
+}
+
+func setExternalDataTimeout(cm *corev1.ConfigMap, config *OperatorConfig) {
 	if val, exists := cm.Data["timeout.external-data-default"]; exists {
 		if parsed, err := time.ParseDuration(val); err == nil {
 			config.Controller.ExternalDataTimeout = parsed
 		}
 	}
+}
+
+func setConditionalTimeout(cm *corev1.ConfigMap, config *OperatorConfig) {
 	if val, exists := cm.Data["timeout.conditional-default"]; exists {
 		if parsed, err := time.ParseDuration(val); err == nil {
 			config.Controller.ConditionalTimeout = parsed
@@ -295,26 +349,46 @@ func parseRetryAndTimeouts(cm *corev1.ConfigMap, config *OperatorConfig) {
 }
 
 func parseLoopConfig(cm *corev1.ConfigMap, config *OperatorConfig) {
+	setMaxLoopIterations(cm, config)
+	setDefaultLoopBatchSize(cm, config)
+	setMaxLoopBatchSize(cm, config)
+	setMaxLoopConcurrency(cm, config)
+	setMaxConcurrencyLimit(cm, config)
+}
+
+func setMaxLoopIterations(cm *corev1.ConfigMap, config *OperatorConfig) {
 	if val, exists := cm.Data["loop.max-iterations"]; exists {
 		if parsed, err := strconv.Atoi(val); err == nil && parsed > 0 {
 			config.Controller.MaxLoopIterations = parsed
 		}
 	}
+}
+
+func setDefaultLoopBatchSize(cm *corev1.ConfigMap, config *OperatorConfig) {
 	if val, exists := cm.Data["loop.default-batch-size"]; exists {
 		if parsed, err := strconv.Atoi(val); err == nil && parsed > 0 {
 			config.Controller.DefaultLoopBatchSize = parsed
 		}
 	}
+}
+
+func setMaxLoopBatchSize(cm *corev1.ConfigMap, config *OperatorConfig) {
 	if val, exists := cm.Data["loop.max-batch-size"]; exists {
 		if parsed, err := strconv.Atoi(val); err == nil && parsed > 0 {
 			config.Controller.MaxLoopBatchSize = parsed
 		}
 	}
+}
+
+func setMaxLoopConcurrency(cm *corev1.ConfigMap, config *OperatorConfig) {
 	if val, exists := cm.Data["loop.max-concurrency"]; exists {
 		if parsed, err := strconv.Atoi(val); err == nil && parsed > 0 {
 			config.Controller.MaxLoopConcurrency = parsed
 		}
 	}
+}
+
+func setMaxConcurrencyLimit(cm *corev1.ConfigMap, config *OperatorConfig) {
 	if val, exists := cm.Data["loop.max-concurrency-limit"]; exists {
 		if parsed, err := strconv.Atoi(val); err == nil && parsed > 0 {
 			config.Controller.MaxConcurrencyLimit = parsed

--- a/internal/controller/runs/rbac.go
+++ b/internal/controller/runs/rbac.go
@@ -31,59 +31,45 @@ func NewRBACManager(k8sClient client.Client, scheme *runtime.Scheme) *RBACManage
 // Reconcile ensures the necessary ServiceAccount, Role, and RoleBinding exist for the StoryRun.
 func (r *RBACManager) Reconcile(ctx context.Context, storyRun *runsv1alpha1.StoryRun) error {
 	log := logging.NewReconcileLogger(ctx, "storyrun-rbac")
-
-	story, err := r.getStoryForRun(ctx, storyRun)
-	if err != nil {
-		// If the story isn't found, we can't determine the storage policy, but we can still proceed
-		// with the basic RBAC setup. The error will be handled in the main reconcile loop.
-		log.Error(err, "Could not get parent story for RBAC setup, proceeding without storage policy")
-	}
+	story, _ := r.getStoryForRun(ctx, storyRun)
 
 	saName := fmt.Sprintf("%s-engram-runner", storyRun.Name)
-	sa := &corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      saName,
-			Namespace: storyRun.Namespace,
-		},
+	if err := r.reconcileServiceAccount(ctx, storyRun, story, saName, log); err != nil {
+		return err
 	}
+	if err := r.reconcileRole(ctx, storyRun, saName, log); err != nil {
+		return err
+	}
+	if err := r.reconcileRoleBinding(ctx, storyRun, saName, log); err != nil {
+		return err
+	}
+	return nil
+}
 
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, sa, func() error {
+func (r *RBACManager) reconcileServiceAccount(ctx context.Context, storyRun *runsv1alpha1.StoryRun, story *bubuv1alpha1.Story, saName string, log *logging.ReconcileLogger) error {
+	sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: saName, Namespace: storyRun.Namespace}}
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, sa, func() error {
 		if sa.Annotations == nil {
 			sa.Annotations = make(map[string]string)
 		}
-
-		if story != nil && story.Spec.Policy != nil && story.Spec.Policy.Storage != nil && story.Spec.Policy.Storage.S3 != nil &&
-			story.Spec.Policy.Storage.S3.Authentication.ServiceAccountAnnotations != nil {
+		if story != nil && story.Spec.Policy != nil && story.Spec.Policy.Storage != nil && story.Spec.Policy.Storage.S3 != nil && story.Spec.Policy.Storage.S3.Authentication.ServiceAccountAnnotations != nil {
 			log.Info("Applying S3 ServiceAccount annotations from StoragePolicy")
 			for k, v := range story.Spec.Policy.Storage.S3.Authentication.ServiceAccountAnnotations {
 				sa.Annotations[k] = v
 			}
 		}
-
 		return controllerutil.SetOwnerReference(storyRun, sa, r.Scheme)
 	})
-
 	if err != nil {
 		return fmt.Errorf("failed to create or update ServiceAccount: %w", err)
 	}
+	return nil
+}
 
+func (r *RBACManager) reconcileRole(ctx context.Context, storyRun *runsv1alpha1.StoryRun, saName string, log *logging.ReconcileLogger) error {
 	role := &rbacv1.Role{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      saName,
-			Namespace: storyRun.Namespace,
-		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{"runs.bubustack.io"},
-				Resources: []string{"stepruns"},
-				Verbs:     []string{"get", "watch"},
-			},
-			{
-				APIGroups: []string{"runs.bubustack.io"},
-				Resources: []string{"stepruns/status"},
-				Verbs:     []string{"patch", "update"},
-			},
-		},
+		ObjectMeta: metav1.ObjectMeta{Name: saName, Namespace: storyRun.Namespace},
+		Rules:      []rbacv1.PolicyRule{{APIGroups: []string{"runs.bubustack.io"}, Resources: []string{"stepruns"}, Verbs: []string{"get", "watch"}}, {APIGroups: []string{"runs.bubustack.io"}, Resources: []string{"stepruns/status"}, Verbs: []string{"patch", "update"}}},
 	}
 	if err := controllerutil.SetOwnerReference(storyRun, role, r.Scheme); err != nil {
 		return fmt.Errorf("failed to set owner reference on Role: %w", err)
@@ -93,24 +79,14 @@ func (r *RBACManager) Reconcile(ctx context.Context, storyRun *runsv1alpha1.Stor
 	} else if err == nil {
 		log.Info("Created Role for Engram runner", "role", role.Name)
 	}
+	return nil
+}
 
+func (r *RBACManager) reconcileRoleBinding(ctx context.Context, storyRun *runsv1alpha1.StoryRun, saName string, log *logging.ReconcileLogger) error {
 	rb := &rbacv1.RoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      saName,
-			Namespace: storyRun.Namespace,
-		},
-		Subjects: []rbacv1.Subject{
-			{
-				Kind:      "ServiceAccount",
-				Name:      saName,
-				Namespace: storyRun.Namespace,
-			},
-		},
-		RoleRef: rbacv1.RoleRef{
-			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "Role",
-			Name:     saName,
-		},
+		ObjectMeta: metav1.ObjectMeta{Name: saName, Namespace: storyRun.Namespace},
+		Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: saName, Namespace: storyRun.Namespace}},
+		RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: saName},
 	}
 	if err := controllerutil.SetOwnerReference(storyRun, rb, r.Scheme); err != nil {
 		return fmt.Errorf("failed to set owner reference on RoleBinding: %w", err)
@@ -120,7 +96,6 @@ func (r *RBACManager) Reconcile(ctx context.Context, storyRun *runsv1alpha1.Stor
 	} else if err == nil {
 		log.Info("Created RoleBinding for Engram runner", "roleBinding", rb.Name)
 	}
-
 	return nil
 }
 

--- a/internal/setup/indexing.go
+++ b/internal/setup/indexing.go
@@ -21,135 +21,128 @@ var setupLog = log.Log.WithName("setup")
 func SetupIndexers(ctx context.Context, mgr manager.Manager) {
 	setupLog.Info("setting up field indexes")
 
-	// Index Engrams by the EngramTemplate they reference.
-	if err := mgr.GetFieldIndexer().IndexField(ctx, &bubushv1alpha1.Engram{}, "spec.templateRef.name", func(rawObj client.Object) []string {
-		engram := rawObj.(*bubushv1alpha1.Engram)
-		if engram.Spec.TemplateRef.Name == "" {
-			return nil
-		}
-		return []string{engram.Spec.TemplateRef.Name}
-	}); err != nil {
-		setupLog.Error(err, "failed to index Engram spec.templateRef.name")
-		os.Exit(1)
-	}
+	mustIndexField(ctx, mgr, &bubushv1alpha1.Engram{}, "spec.templateRef.name", extractEngramTemplateName, "failed to index Engram spec.templateRef.name")
 
-	// Index StepRuns by the Engram they reference.
-	if err := mgr.GetFieldIndexer().IndexField(ctx, &runsv1alpha1.StepRun{}, "spec.engramRef", func(rawObj client.Object) []string {
-		stepRun := rawObj.(*runsv1alpha1.StepRun)
-		if stepRun.Spec.EngramRef == nil || stepRun.Spec.EngramRef.Name == "" {
-			return nil
-		}
-		return []string{stepRun.Spec.EngramRef.Name}
-	}); err != nil {
-		setupLog.Error(err, "failed to index StepRun spec.engramRef.name")
-		os.Exit(1)
-	}
+	mustIndexField(ctx, mgr, &runsv1alpha1.StepRun{}, "spec.engramRef", extractStepRunEngramRef, "failed to index StepRun spec.engramRef.name")
 
-	// Index StepRuns by the StoryRun they belong to.
-	if err := mgr.GetFieldIndexer().IndexField(ctx, &runsv1alpha1.StepRun{}, "spec.storyRunRef.name", func(rawObj client.Object) []string {
-		stepRun := rawObj.(*runsv1alpha1.StepRun)
-		if stepRun.Spec.StoryRunRef.Name == "" {
-			return nil
-		}
-		return []string{stepRun.Spec.StoryRunRef.Name}
-	}); err != nil {
-		setupLog.Error(err, "failed to index StepRun spec.storyRunRef.name")
-		os.Exit(1)
-	}
+	mustIndexField(ctx, mgr, &runsv1alpha1.StepRun{}, "spec.storyRunRef.name", extractStepRunStoryRunRef, "failed to index StepRun spec.storyRunRef.name")
 
-	// Index StoryRuns by the Impulse that triggered them.
-	if err := mgr.GetFieldIndexer().IndexField(ctx, &runsv1alpha1.StoryRun{}, "spec.impulseRef.name", func(rawObj client.Object) []string {
-		storyRun := rawObj.(*runsv1alpha1.StoryRun)
-		if storyRun.Spec.ImpulseRef == nil || storyRun.Spec.ImpulseRef.Name == "" {
-			return nil
-		}
-		return []string{storyRun.Spec.ImpulseRef.Name}
-	}); err != nil {
-		setupLog.Error(err, "failed to index StoryRun spec.impulseRef.name")
-		os.Exit(1)
-	}
+	mustIndexField(ctx, mgr, &runsv1alpha1.StoryRun{}, "spec.impulseRef.name", extractStoryRunImpulseRef, "failed to index StoryRun spec.impulseRef.name")
 
-	// Index Impulses by the ImpulseTemplate they reference.
-	if err := mgr.GetFieldIndexer().IndexField(ctx, &bubushv1alpha1.Impulse{}, "spec.templateRef.name", func(rawObj client.Object) []string {
-		impulse := rawObj.(*bubushv1alpha1.Impulse)
-		if impulse.Spec.TemplateRef.Name == "" {
-			return nil
-		}
-		return []string{impulse.Spec.TemplateRef.Name}
-	}); err != nil {
-		setupLog.Error(err, "failed to index Impulse spec.templateRef.name")
-		os.Exit(1)
-	}
+	mustIndexField(ctx, mgr, &bubushv1alpha1.Impulse{}, "spec.templateRef.name", extractImpulseTemplateName, "failed to index Impulse spec.templateRef.name")
 
-	// Index StoryRuns by the Story they reference.
-	if err := mgr.GetFieldIndexer().IndexField(ctx, &runsv1alpha1.StoryRun{}, "spec.storyRef.name", func(rawObj client.Object) []string {
-		storyRun := rawObj.(*runsv1alpha1.StoryRun)
-		if storyRun.Spec.StoryRef.Name == "" {
-			return nil
-		}
-		return []string{storyRun.Spec.StoryRef.Name}
-	}); err != nil {
-		setupLog.Error(err, "failed to index StoryRun spec.storyRef.name")
-		os.Exit(1)
-	}
+	mustIndexField(ctx, mgr, &runsv1alpha1.StoryRun{}, "spec.storyRef.name", extractStoryRunStoryRefName, "failed to index StoryRun spec.storyRef.name")
 
-	// Index Impulses by the Story they trigger.
-	if err := mgr.GetFieldIndexer().IndexField(ctx, &bubushv1alpha1.Impulse{}, "spec.storyRef.name", func(rawObj client.Object) []string {
-		impulse := rawObj.(*bubushv1alpha1.Impulse)
-		if impulse.Spec.StoryRef.Name == "" {
-			return nil
-		}
-		return []string{impulse.Spec.StoryRef.Name}
-	}); err != nil {
-		setupLog.Error(err, "failed to index Impulse spec.storyRef.name")
-		os.Exit(1)
-	}
+	mustIndexField(ctx, mgr, &bubushv1alpha1.Impulse{}, "spec.storyRef.name", extractImpulseStoryRefName, "failed to index Impulse spec.storyRef.name")
 
-	// Index Stories by Engram names referenced in steps (spec.steps[].ref.name)
-	if err := mgr.GetFieldIndexer().IndexField(ctx, &bubushv1alpha1.Story{}, "spec.steps.ref.name", func(rawObj client.Object) []string {
-		story := rawObj.(*bubushv1alpha1.Story)
-		if len(story.Spec.Steps) == 0 {
-			return nil
-		}
-		nameSet := make(map[string]struct{})
-		for i := range story.Spec.Steps {
-			step := &story.Spec.Steps[i]
-			if step.Ref != nil && step.Ref.Name != "" {
-				nameSet[step.Ref.Name] = struct{}{}
-			}
-		}
-		if len(nameSet) == 0 {
-			return nil
-		}
-		out := make([]string, 0, len(nameSet))
-		for n := range nameSet {
-			out = append(out, n)
-		}
-		return out
-	}); err != nil {
-		setupLog.Error(err, "failed to index Story spec.steps.ref.name")
-		os.Exit(1)
-	}
+	mustIndexField(ctx, mgr, &bubushv1alpha1.Story{}, "spec.steps.ref.name", extractStoryStepEngramRefs, "failed to index Story spec.steps.ref.name")
 
-	// Index EngramTemplates by description.
-	if err := mgr.GetFieldIndexer().IndexField(ctx, &catalogv1alpha1.EngramTemplate{}, "spec.description",
-		func(obj client.Object) []string {
-			template := obj.(*catalogv1alpha1.EngramTemplate)
-			if template.Spec.Description != "" {
-				return []string{template.Spec.Description}
-			}
-			return []string{"no-description"}
-		}); err != nil {
-		setupLog.Error(err, "failed to index EngramTemplate spec.description")
-		os.Exit(1)
-	}
+	mustIndexField(ctx, mgr, &catalogv1alpha1.EngramTemplate{}, "spec.description", extractEngramTemplateDescription, "failed to index EngramTemplate spec.description")
 
-	// Index EngramTemplates by version.
-	if err := mgr.GetFieldIndexer().IndexField(ctx, &catalogv1alpha1.EngramTemplate{}, "spec.version",
-		func(obj client.Object) []string {
-			return []string{obj.(*catalogv1alpha1.EngramTemplate).Spec.Version}
-		}); err != nil {
-		setupLog.Error(err, "failed to index EngramTemplate spec.version")
+	mustIndexField(ctx, mgr, &catalogv1alpha1.EngramTemplate{}, "spec.version", extractEngramTemplateVersion, "failed to index EngramTemplate spec.version")
+}
+
+// mustIndexField registers an index and terminates the process if registration fails.
+func mustIndexField(
+	ctx context.Context,
+	mgr manager.Manager,
+	obj client.Object,
+	field string,
+	extractor func(client.Object) []string,
+	errMsg string,
+) {
+	if err := mgr.GetFieldIndexer().IndexField(ctx, obj, field, extractor); err != nil {
+		setupLog.Error(err, errMsg)
 		os.Exit(1)
 	}
+}
+
+func extractEngramTemplateName(rawObj client.Object) []string {
+	engram := rawObj.(*bubushv1alpha1.Engram)
+	if engram.Spec.TemplateRef.Name == "" {
+		return nil
+	}
+	return []string{engram.Spec.TemplateRef.Name}
+}
+
+func extractStepRunEngramRef(rawObj client.Object) []string {
+	stepRun := rawObj.(*runsv1alpha1.StepRun)
+	if stepRun.Spec.EngramRef == nil || stepRun.Spec.EngramRef.Name == "" {
+		return nil
+	}
+	return []string{stepRun.Spec.EngramRef.Name}
+}
+
+func extractStepRunStoryRunRef(rawObj client.Object) []string {
+	stepRun := rawObj.(*runsv1alpha1.StepRun)
+	if stepRun.Spec.StoryRunRef.Name == "" {
+		return nil
+	}
+	return []string{stepRun.Spec.StoryRunRef.Name}
+}
+
+func extractStoryRunImpulseRef(rawObj client.Object) []string {
+	storyRun := rawObj.(*runsv1alpha1.StoryRun)
+	if storyRun.Spec.ImpulseRef == nil || storyRun.Spec.ImpulseRef.Name == "" {
+		return nil
+	}
+	return []string{storyRun.Spec.ImpulseRef.Name}
+}
+
+func extractImpulseTemplateName(rawObj client.Object) []string {
+	impulse := rawObj.(*bubushv1alpha1.Impulse)
+	if impulse.Spec.TemplateRef.Name == "" {
+		return nil
+	}
+	return []string{impulse.Spec.TemplateRef.Name}
+}
+
+func extractStoryRunStoryRefName(rawObj client.Object) []string {
+	storyRun := rawObj.(*runsv1alpha1.StoryRun)
+	if storyRun.Spec.StoryRef.Name == "" {
+		return nil
+	}
+	return []string{storyRun.Spec.StoryRef.Name}
+}
+
+func extractImpulseStoryRefName(rawObj client.Object) []string {
+	impulse := rawObj.(*bubushv1alpha1.Impulse)
+	if impulse.Spec.StoryRef.Name == "" {
+		return nil
+	}
+	return []string{impulse.Spec.StoryRef.Name}
+}
+
+func extractStoryStepEngramRefs(rawObj client.Object) []string {
+	story := rawObj.(*bubushv1alpha1.Story)
+	if len(story.Spec.Steps) == 0 {
+		return nil
+	}
+	nameSet := make(map[string]struct{})
+	for i := range story.Spec.Steps {
+		step := &story.Spec.Steps[i]
+		if step.Ref != nil && step.Ref.Name != "" {
+			nameSet[step.Ref.Name] = struct{}{}
+		}
+	}
+	if len(nameSet) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(nameSet))
+	for n := range nameSet {
+		out = append(out, n)
+	}
+	return out
+}
+
+func extractEngramTemplateDescription(obj client.Object) []string {
+	template := obj.(*catalogv1alpha1.EngramTemplate)
+	if template.Spec.Description != "" {
+		return []string{template.Spec.Description}
+	}
+	return []string{"no-description"}
+}
+
+func extractEngramTemplateVersion(obj client.Object) []string {
+	return []string{obj.(*catalogv1alpha1.EngramTemplate).Spec.Version}
 }

--- a/internal/webhook/v1alpha1/validate_helpers.go
+++ b/internal/webhook/v1alpha1/validate_helpers.go
@@ -1,0 +1,59 @@
+package v1alpha1
+
+import (
+	"fmt"
+
+	"github.com/xeipuuv/gojsonschema"
+
+	"github.com/bubustack/bobrapet/internal/config"
+)
+
+func trimLeadingSpace(b []byte) []byte {
+	for len(b) > 0 {
+		if b[0] == ' ' || b[0] == '\n' || b[0] == '\t' || b[0] == '\r' {
+			b = b[1:]
+			continue
+		}
+		break
+	}
+	return b
+}
+
+func ensureJSONObject(field string, b []byte) error {
+	if len(b) > 0 && b[0] != '{' {
+		return fmt.Errorf("%s must be a JSON object", field)
+	}
+	return nil
+}
+
+func pickMaxInline(cfg *config.ControllerConfig) int {
+	maxBytes := cfg.Engram.EngramControllerConfig.DefaultMaxInlineSize
+	if maxBytes == 0 {
+		maxBytes = 1024
+	}
+	return maxBytes
+}
+
+func enforceMaxBytes(field string, raw []byte, max int) error {
+	if len(raw) > max {
+		return fmt.Errorf("%s too large (%d bytes). Provide large payloads via object storage and references instead of inlining", field, len(raw))
+	}
+	return nil
+}
+
+func validateJSONAgainstSchema(doc []byte, schema []byte, schemaName string) error {
+	schemaLoader := gojsonschema.NewStringLoader(string(schema))
+	documentLoader := gojsonschema.NewStringLoader(string(doc))
+	result, err := gojsonschema.Validate(schemaLoader, documentLoader)
+	if err != nil {
+		return fmt.Errorf("error validating against %s schema: %w", schemaName, err)
+	}
+	if !result.Valid() {
+		var errs []string
+		for _, desc := range result.Errors() {
+			errs = append(errs, desc.String())
+		}
+		return fmt.Errorf("object is invalid against %s schema: %v", schemaName, errs)
+	}
+	return nil
+}


### PR DESCRIPTION
harden reconcile context, validation, and storage guards

- Reconcile context/timeout:
  - Apply controller-configured deadlines across StoryRun/StepRun/RealtimeEngram.
  - Ensure status patches and external calls use the passed ctx; no background contexts.

- Conditions/status/metrics:
  - Standardize condition reasons via pkg/conditions; consistent status patch helpers.
  - Record reconcile duration metrics; emit user-facing Events where actionable.

- StoryRun/DAG:
  - Guard oversized spec.inputs (prevent etcd bloat); rely on watches for progress.
  - RBACManager to provision per-run SA/Role/RoleBinding with least privilege.
  - DAG avoids embedding step outputs in parent; resolves from StepRuns on demand.
  - Streaming improvements (per-story/per-run handling) and safe finalization.

- StepRun:
  - Idempotent finalizer add/remove; background cleanup for owned Jobs.
  - Fallback status updates (Succeeded/Failed) with exit code classification.
  - Wire SDK envs (BUBU_*) and optional S3 storage envs from resolved config.

- RealtimeEngram:
  - Finalizer lifecycle; service/workload reconcile; template resolution with Ready.

- Indexing:
  - Add field indexers (templateRef, story refs, engram refs) for efficient watches.

- Webhooks (validating):
  - StoryRun: require storyRef; inputs shape/size check; JSON schema validation.
  - StepRun: require storyRunRef/stepId; input/status size guard; total size guard.
  - Add shared validation helpers.

- Config:
  - OperatorConfigManager/Resolver extensions (timeouts, security, retries, GRPC).
  - Safer defaults for inline size and timeouts.

- CI/Lint:
  - Update release-please workflow/config and golangci settings.

Pre-flight:
- go vet ./... OK
- go build ./... OK
- go test ./... -race OK